### PR TITLE
Removed usage of FF specific explicitOriginalTarget.

### DIFF
--- a/angular-deep-blur.js
+++ b/angular-deep-blur.js
@@ -38,10 +38,9 @@
 
                     function onBlur(e) {
                         // e.relatedTarget for Chrome
-                        // explicitOriginalTarget for Firefox
                         // document.activeElement for IE 11
-                        var targetElement = e.relatedTarget || e.explicitOriginalTarget || document.activeElement;
-                        
+                        var targetElement = e.relatedTarget || document.activeElement;
+
                         if (!containsDom(dom, targetElement)) {
                             $timeout(function () {
                                 $scope.$apply(leaveExpr);


### PR DESCRIPTION
Unfortunately using `explicitOriginalTarget` is not a perfect workaround and creates potential problem. Apparently it will be set to the trigger of the event in some cases as per [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=962251#c8) on the related bug report.
